### PR TITLE
Fixes RT#90686 Moose enum warnings

### DIFF
--- a/lib/POE/Component/Client/MPD/Types.pm
+++ b/lib/POE/Component/Client/MPD/Types.pm
@@ -10,8 +10,8 @@ use Sub::Exporter -setup => { exports => [ qw{
     Cooking Transform
 } ] };
 
-enum Cooking   => qw{ raw as_items as_kv strip_first };
-enum Transform => qw{ as_scalar as_stats as_status };
+enum Cooking   => [qw{ raw as_items as_kv strip_first }];
+enum Transform => [qw{ as_scalar as_stats as_status }];
 
 1;
 __END__


### PR DESCRIPTION
This fixes RT#90686 : warnings produced by the change to the way enum should be called.

See https://rt.cpan.org/Ticket/Display.html?id=90686 
